### PR TITLE
Added minlength option for leading zeros

### DIFF
--- a/assets/coffee/tick.coffee
+++ b/assets/coffee/tick.coffee
@@ -65,7 +65,7 @@ class Tick
       delay     : options.delay or 1000
       separators: if options.separators? then options.separators else false
       autostart : if options.autostart?  then options.autostart  else true
-      minlength : options.minlength or 1
+      minlength : parseInt(options.minlength, 10) or 1
 
     @increment = @build_increment_callback( options.incremental )
 

--- a/assets/coffee/tick.coffee
+++ b/assets/coffee/tick.coffee
@@ -46,6 +46,7 @@ $.fn.ticker = (options) ->
     separators    boolean   if true, all arbitrary characters inbetween digits are wrapped in seperated elements
                             if false, these characters are stripped out
     autostart     boolean   whether or not to start the ticker when instantiated
+    minlength     int       minimum length of the element, leading zeros will be put in place if not long enough
 
   Events
 
@@ -64,6 +65,7 @@ class Tick
       delay     : options.delay or 1000
       separators: if options.separators? then options.separators else false
       autostart : if options.autostart?  then options.autostart  else true
+      minlength : options.minlength or 1
 
     @increment = @build_increment_callback( options.incremental )
 
@@ -96,8 +98,14 @@ class Tick
 
   render: () ->
 
-    digits      = String( @value ).split( '' )
+    digits      = String( @value )
     containers  = @element.children( ':not(.tick-separator)' )
+
+    # add leading zeros if length is not long enough
+    if digits.length < @options.minlength
+      while (digits.length < @options.minlength)
+        digits = "0" + digits
+      digits.split( '' )
 
     # add new containers for each digit that doesnt exist (if they do, just update them)
     if digits.length > containers.length

--- a/assets/coffee/tick.coffee
+++ b/assets/coffee/tick.coffee
@@ -105,7 +105,6 @@ class Tick
     if digits.length < @options.minlength
       while (digits.length < @options.minlength)
         digits = "0" + digits
-        @separators.unshift('')
 
     # add new containers for each digit that doesnt exist (if they do, just update them)
     if digits.length > containers.length

--- a/assets/coffee/tick.coffee
+++ b/assets/coffee/tick.coffee
@@ -105,6 +105,7 @@ class Tick
     if digits.length < @options.minlength
       while (digits.length < @options.minlength)
         digits = "0" + digits
+        @separators.unshift('')
 
     # add new containers for each digit that doesnt exist (if they do, just update them)
     if digits.length > containers.length

--- a/assets/coffee/tick.coffee
+++ b/assets/coffee/tick.coffee
@@ -105,7 +105,6 @@ class Tick
     if digits.length < @options.minlength
       while (digits.length < @options.minlength)
         digits = "0" + digits
-      digits.split( '' )
 
     # add new containers for each digit that doesnt exist (if they do, just update them)
     if digits.length > containers.length

--- a/assets/js/tick.js
+++ b/assets/js/tick.js
@@ -70,7 +70,7 @@
         delay: options.delay || 1000,
         separators: options.separators != null ? options.separators : false,
         autostart: options.autostart != null ? options.autostart : true,
-        minlength: options.minlength || 1
+        minlength: parseInt(options.minlength, 10) || 1
       };
       this.increment = this.build_increment_callback(options.incremental);
       this.value = Number(this.element.html().replace(/[^\d.]/g, ''));

--- a/assets/js/tick.js
+++ b/assets/js/tick.js
@@ -49,6 +49,7 @@
       separators    boolean   if true, all arbitrary characters inbetween digits are wrapped in seperated elements
                               if false, these characters are stripped out
       autostart     boolean   whether or not to start the ticker when instantiated
+      minlength     int       minimum length of the element, leading zeros will be put in place if not long enough
   
     Events
   
@@ -68,7 +69,8 @@
       this.options = {
         delay: options.delay || 1000,
         separators: options.separators != null ? options.separators : false,
-        autostart: options.autostart != null ? options.autostart : true
+        autostart: options.autostart != null ? options.autostart : true,
+        minlength: options.minlength || 1
       };
       this.increment = this.build_increment_callback(options.incremental);
       this.value = Number(this.element.html().replace(/[^\d.]/g, ''));
@@ -95,8 +97,14 @@
 
     Tick.prototype.render = function() {
       var container, containers, digits, i, _i, _j, _k, _len, _ref, _ref1, _ref2, _results;
-      digits = String(this.value).split('');
+      digits = String(this.value);
       containers = this.element.children(':not(.tick-separator)');
+      if (digits.length < this.options.minlength) {
+        while (digits.length < this.options.minlength) {
+          digits = "0" + digits;
+        }
+        digits.split('');
+      }
       if (digits.length > containers.length) {
         for (i = _i = 0, _ref = digits.length - containers.length; 0 <= _ref ? _i < _ref : _i > _ref; i = 0 <= _ref ? ++_i : --_i) {
           if (this.options.separators && this.separators[i]) {

--- a/assets/js/tick.js
+++ b/assets/js/tick.js
@@ -103,7 +103,6 @@
         while (digits.length < this.options.minlength) {
           digits = "0" + digits;
         }
-        digits.split('');
       }
       if (digits.length > containers.length) {
         for (i = _i = 0, _ref = digits.length - containers.length; 0 <= _ref ? _i < _ref : _i > _ref; i = 0 <= _ref ? ++_i : --_i) {

--- a/assets/js/tick.js
+++ b/assets/js/tick.js
@@ -102,7 +102,6 @@
       if (digits.length < this.options.minlength) {
         while (digits.length < this.options.minlength) {
           digits = "0" + digits;
-          this.separators.unshift('');
         }
       }
       if (digits.length > containers.length) {

--- a/assets/js/tick.js
+++ b/assets/js/tick.js
@@ -102,6 +102,7 @@
       if (digits.length < this.options.minlength) {
         while (digits.length < this.options.minlength) {
           digits = "0" + digits;
+          this.separators.unshift('');
         }
       }
       if (digits.length > containers.length) {


### PR DESCRIPTION
[This Issue](https://github.com/harvesthq/tick/issues/8) was closed but i recently felt the need for exactly this functionality. The response to this issue was that it wouldn't be possible because of the max value would stop the timer if the value hit the max. But it is possible if you think of it from a minimum instead of maximum.

Heres my solution I added an optional minlength value that would default to 1. Then on each render added a check to see if the number of digits is below the min if so it will add leading zeros. If the value is larger then the minlength it will still continue on ticking. It would only add leading zeros if it is needed.

This is useful when your making a clock or a minutes ticker in a timer. For example `8:04` if you had a ticker on the minutes it would be `8:4`. It is like this because of the Number() function used to get the value, it strips away any leading zeros.

To give a few examples with a minlength of  `2` :
- Value of `4`, it will add a leading zero to make it `04`.
- Value of `15`, will not add zeros will stay `15`
- Value of `350`, also will not add zeros stays `350`
